### PR TITLE
fix: When customized redirectUrl is set it doesn't always have to include the /authorize

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -110,7 +110,7 @@ module.exports.apifyGoogleAuth = async ({ scope, tokensStore, credentials, googl
         console.log(information);
 
         const server = http.createServer((req, res) => {
-            if (req.url.includes('/authorize')) {
+            if (/[?&]code=/.test(req.url)) {
                 let data = '';
                 req.on('data', (body) => {
                     if (body) data += body;

--- a/src/main.js
+++ b/src/main.js
@@ -110,13 +110,13 @@ module.exports.apifyGoogleAuth = async ({ scope, tokensStore, credentials, googl
         console.log(information);
 
         const server = http.createServer((req, res) => {
-            if (/[?&]code=/.test(req.url)) {
+            code = new URL(req.url, pickedCredentials.redirect_uri).searchParams.get('code');
+            if (code) {
                 let data = '';
                 req.on('data', (body) => {
                     if (body) data += body;
                 });
                 req.on('end', () => {
-                    code = decodeURIComponent(data.replace('code=', ''));
                     res.end(close());
                 });
             } else {


### PR DESCRIPTION
Current implementation force user to setup specific url path even thought the implement that the evaluation for code is more dependent on the `code` search parameter in the url. 

So when user set only `containerUrl` for `redirectUrl` everything works except the code is not automatically determined and this step has to be done manually with some url decoding.